### PR TITLE
YSMOD-78 Setter enhet til null dersom enhet er nedlagt

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/task/ProsesserJournalfoertSkanningTask.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/task/ProsesserJournalfoertSkanningTask.kt
@@ -16,6 +16,7 @@ import no.nav.yrkesskade.meldingmottak.clients.graphql.PdlClient
 import no.nav.yrkesskade.meldingmottak.clients.graphql.SafClient
 import no.nav.yrkesskade.meldingmottak.util.FristFerdigstillelseTimeManager
 import no.nav.yrkesskade.meldingmottak.util.extensions.hentHovedDokumentTittel
+import no.nav.yrkesskade.meldingmottak.util.extensions.journalfoerendeEnhetEllerNull
 import no.nav.yrkesskade.meldingmottak.util.getSecureLogger
 import no.nav.yrkesskade.prosessering.AsyncTaskStep
 import no.nav.yrkesskade.prosessering.TaskStepBeskrivelse
@@ -64,7 +65,7 @@ class ProsesserJournalfoertSkanningTask(
                 journalpostId = journalpost.journalpostId,
                 aktoerId = aktoerId,
                 tema = journalpost.tema.toString(),
-                tildeltEnhetsnr = journalpost.journalfoerendeEnhet,
+                tildeltEnhetsnr = journalpost.journalfoerendeEnhetEllerNull(),
                 oppgavetype = Oppgavetype.JOURNALFOERING.kortnavn,
                 behandlingstema = null, // skal være null
                 behandlingstype = null, // skal være null

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/util/extensions/JournalpostExt.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/util/extensions/JournalpostExt.kt
@@ -5,3 +5,21 @@ import com.expediagroup.graphql.generated.journalpost.Journalpost
 fun Journalpost.hentHovedDokumentTittel(): String {
     return dokumenter?.firstOrNull { it!!.brevkode != null }?.tittel.orEmpty()
 }
+
+/**
+ * journalfoerendeEnhet overstyrer enheten som journalføringen skal tilhøre i Oppgave.
+ * Noen ganger er dette en nedlagt enhet, grunnet bruk av utdatert forside på skanningen ol.
+ * Dette er en midlertidig funksjon vi bruker for å sørge for at vi ikke sender nedlagt enhet til Oppgave-APIet.
+ *
+ */
+fun Journalpost.journalfoerendeEnhetEllerNull(): String? {
+    if (journalfoerendeEnhet == null) {
+        return null
+    }
+
+    val nedlagteEnheter = listOf("0889")
+    if (nedlagteEnheter.contains(journalfoerendeEnhet)) {
+        return null
+    }
+    return journalfoerendeEnhet
+}

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/util/extensions/JournalpostExtKtTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/util/extensions/JournalpostExtKtTest.kt
@@ -1,0 +1,30 @@
+package no.nav.yrkesskade.meldingmottak.util.extensions
+
+import no.nav.yrkesskade.meldingmottak.fixtures.gyldigJournalpostMedAktoerId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class JournalpostExtKtTest {
+
+    @Test
+    fun `journalfoerendeEnhetEllerNull gir null naar journalfoerendeEnhet er null`() {
+        val journalpostMedNullSomEnhet = gyldigJournalpostMedAktoerId().copy(
+            journalfoerendeEnhet = null
+        )
+        assertThat(journalpostMedNullSomEnhet.journalfoerendeEnhetEllerNull()).isNull()
+    }
+
+    @Test
+    fun `journalfoerendeEnhetEllerNull gir 4849 naar journalfoerendeEnhet er 4849`() {
+        val journalpost = gyldigJournalpostMedAktoerId()
+        assertThat(journalpost.journalfoerendeEnhetEllerNull()).isEqualTo(journalpost.journalfoerendeEnhet)
+    }
+
+    @Test
+    fun `journalfoerendeEnhetEllerNull gir null naar journalfoerendeEnhet er nedlagt`() {
+        val journalpostMedNedlagtEnhet = gyldigJournalpostMedAktoerId().copy(
+            journalfoerendeEnhet = "0889"
+        )
+        assertThat(journalpostMedNedlagtEnhet.journalfoerendeEnhetEllerNull()).isNull()
+    }
+}


### PR DESCRIPTION
Nå som vi videresender journalførende enhet til oppgave-apiet, hender det at vi får inn enheter som er nedlagte, grunnet gamle forsider o.l. 
Disse må vi luke bort. Dette kan løses mer ordentlig med en integrasjon mot Norg, men holder det pragmatisk inntil videre.