### PR TITLE
Alert for at en eller flere kafka consumere begynner å henge etter

### DIFF
--- a/.nais/alerts-dev.yaml
+++ b/.nais/alerts-dev.yaml
@@ -26,7 +26,7 @@ spec:
     sla: Responder innen 1 time i kontortid
     severity: warning
   - alert: Økende Kafka consumer lag
-    expr: sum(delta(kafka_consumergroup_group_topic_sum_lag{group="yrkesskade-melding-mottak" }[5m])) by(group, topic)/(5*60) >5
+    expr: sum(delta(kafka_consumergroup_group_topic_sum_lag{group="yrkesskade-melding-mottak"}[5m])) by(group, topic)/(5*60) >5
     for: 5m
     description: "consumer group *{{ $labels.group }}* øker med  {{ $value }} pr sekund på *{{ $labels.topic }}*"
     action: "Sjekk logger"


### PR DESCRIPTION
Inspirert av team bømlo: https://github.com/navikt/bomlo-alerts/blob/a20c49a8cb9b24054fc02f9f110194a2edf5efb0/bomlo-alerts-gcp.yaml#L37 

Tenker vi tester alerten i dev først, og hvis den ser ut til å oppføre seg som den skal så legger vi til i prod også.