### PR TITLE
Feature/ysmod 118 vise land i pdfer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>no.nav.yrkesskade</groupId>
     <artifactId>yrkesskade-melding-mottak</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>ys-melding-mottak</name>
     <description>Mottaksmodul for innsendte meldinger om yrkesskade, -sykdom og menerstatning</description>
 

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/Kodeverkklient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/Kodeverkklient.kt
@@ -46,6 +46,7 @@ class Kodeverkklient(
             .retrieve()
             .bodyToMono<KodeverdiRespons>()
             .block() ?: KodeverdiRespons(emptyMap())
+        // TODO: Send med callid i header for enklere feilsøking
 
         return kodeverdiRespons.kodeverdierMap
     }

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/Kodeverkklient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/Kodeverkklient.kt
@@ -1,0 +1,64 @@
+package no.nav.yrkesskade.meldingmottak.clients
+
+import no.nav.yrkesskade.meldingmottak.domene.Land
+import no.nav.yrkesskade.meldingmottak.domene.Landkode
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
+
+@Component
+class Kodeverkklient(
+    private val kodeverkWebClient: WebClient
+) {
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val log = LoggerFactory.getLogger(javaClass.enclosingClass)
+    }
+
+    @Retryable
+    fun hentLand(spraak: String = "nb"): Map<Landkode, Land> {
+        log.info("Henter land fra ys-kodeverk")
+        return logTimingAndWebClientResponseException("hentLand") {
+            kodeverkWebClient.get()
+                .uri { uriBuilder ->
+                    val typeLandkoder = "landkoderISO2"
+                    val tilfeldigKategori = "arbeidstaker"
+                    uriBuilder.pathSegment("api/v1/kodeverk/typer", typeLandkoder, "kategorier", tilfeldigKategori, "kodeverdier")
+                        .build()
+                }
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono<Map<Landkode, Land>>()
+                .block() ?: emptyMap()
+        }
+    }
+
+    @Suppress("SameParameterValue")
+    private fun <T> logTimingAndWebClientResponseException(methodName: String, function: () -> T): T {
+        val start: Long = System.currentTimeMillis()
+        try {
+            return function.invoke()
+        } catch (ex: WebClientResponseException) {
+            log.error(
+                "Got a {} error calling kodeverk {} {} with message {}",
+                ex.statusCode,
+                ex.request?.method ?: "-",
+                ex.request?.uri ?: "-",
+                ex.responseBodyAsString
+            )
+            throw ex
+        } catch (rtex: RuntimeException) {
+            log.error("Caught RuntimeException while calling kodeverk ", rtex)
+            throw rtex
+        } finally {
+            val end: Long = System.currentTimeMillis()
+            log.info("Method {} took {} millis", methodName, (end - start))
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/Kodeverkklient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/Kodeverkklient.kt
@@ -46,7 +46,7 @@ class Kodeverkklient(
             .retrieve()
             .bodyToMono<KodeverdiRespons>()
             .block() ?: KodeverdiRespons(emptyMap())
-        // TODO: Send med callid i header for enklere feilsøking
+        // TODO: YSMOD-161 - Send med callid i header for enklere feilsøking
 
         return kodeverdiRespons.kodeverdierMap
     }

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/config/FeatureToggleConfig.kt
@@ -88,3 +88,7 @@ interface FeatureToggleService {
 
     fun isEnabled(toggleId: String, defaultValue: Boolean = false): Boolean
 }
+
+enum class FeatureToggles(val toggleId: String) {
+    LANDKODER_TIL_PDF("yrkesskade.landkoder-til-pdf")
+}

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/config/FeatureToggleConfig.kt
@@ -89,6 +89,7 @@ interface FeatureToggleService {
     fun isEnabled(toggleId: String, defaultValue: Boolean = false): Boolean
 }
 
+// TODO: Jira-oppgave YSMOD-144: Fjern feature-toggle for henting av land for visning i utenlandske adresser på pdf
 enum class FeatureToggles(val toggleId: String) {
     LANDKODER_TIL_PDF("yrkesskade.landkoder-til-pdf")
 }

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/config/WebClientConfiguration.kt
@@ -12,7 +12,8 @@ import reactor.netty.http.client.HttpClient
 class WebClientConfiguration(private val webClientBuilder: WebClient.Builder,
                              @Value("\${oppgave.url}") val oppgaveServiceURL: String,
                              @Value("\${dokarkiv.url}") val dokarkivServiceURL: String,
-                             @Value("\${YRKESSKADE_DOKGEN_API_URL}") val pdfServiceURL: String) {
+                             @Value("\${YRKESSKADE_DOKGEN_API_URL}") val pdfServiceURL: String,
+                             @Value("\${YRKESSKADE_KODEVERK_API_URL}") val kodeverkServiceURL: String) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
@@ -39,6 +40,14 @@ class WebClientConfiguration(private val webClientBuilder: WebClient.Builder,
     fun pdfWebClient(): WebClient {
         return webClientBuilder
             .baseUrl(pdfServiceURL)
+            .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
+            .build()
+    }
+
+    @Bean
+    fun kodeverkWebClient(): WebClient {
+        return webClientBuilder
+            .baseUrl(kodeverkServiceURL)
             .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
             .build()
     }

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/domene/Kodeverk.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/domene/Kodeverk.kt
@@ -1,0 +1,8 @@
+package no.nav.yrkesskade.meldingmottak.domene
+
+data class Land(
+    val kode: String,
+    val navn: String
+)
+
+typealias Landkode = String

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/domene/Kodeverk.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/domene/Kodeverk.kt
@@ -1,8 +1,31 @@
 package no.nav.yrkesskade.meldingmottak.domene
 
-data class Land(
-    val kode: String,
-    val navn: String
+import java.time.Instant
+
+typealias KodeverkType = String
+
+typealias KodeverkKategori = String
+
+data class KodeverkTypeKategori(
+    val type: KodeverkType,
+    val kategori: KodeverkKategori
 )
 
-typealias Landkode = String
+typealias KodeverkKode = String
+
+data class KodeverkVerdi(
+    val kode: String,
+    val spraak: String,
+    val verdi: String,
+    val sortering: Int?
+)
+
+data class KodeverdiRespons (
+    var kodeverdierMap: Map<KodeverkKode, KodeverkVerdi> = mutableMapOf()
+)
+
+data class KodeverkTidData(
+    val data: Map<KodeverkKode, KodeverkVerdi>,
+    val hentetTid: Instant = Instant.now()
+)
+

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/pdf/PdfSkademeldingMapper.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/pdf/PdfSkademeldingMapper.kt
@@ -1,6 +1,8 @@
 package no.nav.yrkesskade.meldingmottak.pdf
 
 import no.nav.yrkesskade.meldingmottak.domene.BeriketData
+import no.nav.yrkesskade.meldingmottak.domene.Land
+import no.nav.yrkesskade.meldingmottak.domene.Landkode
 import no.nav.yrkesskade.meldingmottak.domene.Navn
 import no.nav.yrkesskade.meldingmottak.pdf.domene.*
 import no.nav.yrkesskade.model.SkademeldingInnsendtHendelse
@@ -15,14 +17,15 @@ object PdfSkademeldingMapper {
 
     fun tilPdfSkademelding(
         record: SkademeldingInnsendtHendelse,
+        alleLand: Map<Landkode, Land>,
         beriketData: BeriketData? = null
     ) : PdfSkademelding {
 
         val skademelding = record.skademelding
         val innmelder: PdfInnmelder? = tilPdfInnmelder(skademelding.innmelder, beriketData?.innmeldersNavn)
-        val skadelidt: PdfSkadelidt? = tilPdfSkadelidt(skademelding.skadelidt, beriketData?.skadelidtsNavn, beriketData?.skadelidtsBostedsadresse)
+        val skadelidt: PdfSkadelidt? = tilPdfSkadelidt(skademelding.skadelidt, beriketData?.skadelidtsNavn, beriketData?.skadelidtsBostedsadresse, alleLand)
         val skade: PdfSkade? = tilPdfSkade(skademelding.skade)
-        val hendelsesfakta: PdfHendelsesfakta? = tilPdfHendelsesfakta(skademelding.hendelsesfakta)
+        val hendelsesfakta: PdfHendelsesfakta? = tilPdfHendelsesfakta(skademelding.hendelsesfakta, alleLand)
         val dokumentInfo: PdfDokumentInfo = lagPdfDokumentInfo(record.metadata)
 
         return PdfSkademelding(innmelder, skadelidt, skade, hendelsesfakta, dokumentInfo)
@@ -43,7 +46,12 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun tilPdfSkadelidt(skadelidt: Skadelidt?, skadelidtsNavn: Navn?, skadelidtsBostedsadresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?): PdfSkadelidt? {
+    private fun tilPdfSkadelidt(
+        skadelidt: Skadelidt?,
+        skadelidtsNavn: Navn?,
+        skadelidtsBostedsadresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?,
+        alleLand: Map<Landkode, Land>
+    ): PdfSkadelidt? {
         if (skadelidt == null) {
             return null
         }
@@ -51,7 +59,7 @@ object PdfSkademeldingMapper {
         return PdfSkadelidt(
             Soknadsfelt("Fødselsnummer", skadelidt.norskIdentitetsnummer),
             Soknadsfelt("Navn", tilString(skadelidtsNavn)),
-            Soknadsfelt("Bosted", tilPdfAdresse2(skadelidtsBostedsadresse)),
+            Soknadsfelt("Bosted", tilPdfAdresse2(skadelidtsBostedsadresse, alleLand)),
             tilPdfDekningsforhold(skadelidt.dekningsforhold)
         )
     }
@@ -88,7 +96,7 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun tilPdfHendelsesfakta(hendelsesfakta: Hendelsesfakta?): PdfHendelsesfakta? {
+    private fun tilPdfHendelsesfakta(hendelsesfakta: Hendelsesfakta?, alleLand: Map<Landkode, Land>): PdfHendelsesfakta? {
         if (hendelsesfakta == null) {
             return null
         }
@@ -114,7 +122,7 @@ object PdfSkademeldingMapper {
             hvorSkjeddeUlykken = Soknadsfelt("Hvor skjedde ulykken", hendelsesfakta.hvorSkjeddeUlykken.value),
             ulykkessted = PdfUlykkessted(
                 sammeSomVirksomhetensAdresse = Soknadsfelt("Skjedde ulykken på samme adresse", jaNei(hendelsesfakta.ulykkessted.sammeSomVirksomhetensAdresse)),
-                adresse = Soknadsfelt("Adresse", tilPdfAdresse(hendelsesfakta.ulykkessted.adresse))
+                adresse = Soknadsfelt("Adresse", tilPdfAdresse(hendelsesfakta.ulykkessted.adresse, alleLand))
             ),
             aarsakUlykkeTabellAogE = Soknadsfelt("Hva var årsaken til hendelsen og bakgrunn for årsaken", hendelsesfakta.aarsakUlykkeTabellAogE.map { it.value }),
             bakgrunnsaarsakTabellBogG = Soknadsfelt("Hva var bakgrunnen til hendelsen", hendelsesfakta.bakgrunnsaarsakTabellBogG.map { it.value }),
@@ -123,7 +131,7 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun tilPdfAdresse(adresse: Adresse?): PdfAdresse? {
+    private fun tilPdfAdresse(adresse: Adresse?, alleLand: Map<Landkode, Land>): PdfAdresse? {
         if (adresse == null) {
             return null
         }
@@ -132,17 +140,23 @@ object PdfSkademeldingMapper {
             adresselinje1 = adresse.adresselinje1,
             adresselinje2 = adresse.adresselinje2,
             adresselinje3 = adresse.adresselinje3,
-            land = adresse.land
+            land = landNavnEllerKode(adresse.land, alleLand)
         )
     }
 
-    private fun tilPdfAdresse2(adresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?): PdfAdresse {
+    private fun tilPdfAdresse2(adresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?, alleLand: Map<Landkode, Land>): PdfAdresse {
         return PdfAdresse(
             adresselinje1 = adresse?.adresselinje1 ?: "",
             adresselinje2 = adresse?.adresselinje2,
             adresselinje3 = adresse?.adresselinje3,
-            land = adresse?.land
+            land = landNavnEllerKode(adresse?.land, alleLand)
         )
+    }
+
+    private fun landNavnEllerKode(landkode: String?, alleLand: Map<Landkode, Land>): String? {
+        if (landkode == null || landkode == "NO" || landkode == "NOR") return null
+        val land = alleLand[landkode]
+        return land?.navn ?: landkode
     }
 
     private fun lagPdfDokumentInfo(metadata: SkademeldingMetadata): PdfDokumentInfo {

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/pdf/PdfSkademeldingMapper.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/pdf/PdfSkademeldingMapper.kt
@@ -1,8 +1,8 @@
 package no.nav.yrkesskade.meldingmottak.pdf
 
 import no.nav.yrkesskade.meldingmottak.domene.BeriketData
-import no.nav.yrkesskade.meldingmottak.domene.Land
-import no.nav.yrkesskade.meldingmottak.domene.Landkode
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkVerdi
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkKode
 import no.nav.yrkesskade.meldingmottak.domene.Navn
 import no.nav.yrkesskade.meldingmottak.pdf.domene.*
 import no.nav.yrkesskade.model.SkademeldingInnsendtHendelse
@@ -17,7 +17,7 @@ object PdfSkademeldingMapper {
 
     fun tilPdfSkademelding(
         record: SkademeldingInnsendtHendelse,
-        alleLand: Map<Landkode, Land>,
+        alleLand: Map<KodeverkKode, KodeverkVerdi>,
         beriketData: BeriketData? = null
     ) : PdfSkademelding {
 
@@ -50,7 +50,7 @@ object PdfSkademeldingMapper {
         skadelidt: Skadelidt?,
         skadelidtsNavn: Navn?,
         skadelidtsBostedsadresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?,
-        alleLand: Map<Landkode, Land>
+        alleLand: Map<KodeverkKode, KodeverkVerdi>
     ): PdfSkadelidt? {
         if (skadelidt == null) {
             return null
@@ -96,7 +96,7 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun tilPdfHendelsesfakta(hendelsesfakta: Hendelsesfakta?, alleLand: Map<Landkode, Land>): PdfHendelsesfakta? {
+    private fun tilPdfHendelsesfakta(hendelsesfakta: Hendelsesfakta?, alleLand: Map<KodeverkKode, KodeverkVerdi>): PdfHendelsesfakta? {
         if (hendelsesfakta == null) {
             return null
         }
@@ -131,7 +131,7 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun tilPdfAdresse(adresse: Adresse?, alleLand: Map<Landkode, Land>): PdfAdresse? {
+    private fun tilPdfAdresse(adresse: Adresse?, alleLand: Map<KodeverkKode, KodeverkVerdi>): PdfAdresse? {
         if (adresse == null) {
             return null
         }
@@ -144,7 +144,7 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun tilPdfAdresse2(adresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?, alleLand: Map<Landkode, Land>): PdfAdresse {
+    private fun tilPdfAdresse2(adresse: no.nav.yrkesskade.meldingmottak.domene.Adresse?, alleLand: Map<KodeverkKode, KodeverkVerdi>): PdfAdresse {
         return PdfAdresse(
             adresselinje1 = adresse?.adresselinje1 ?: "",
             adresselinje2 = adresse?.adresselinje2,
@@ -153,10 +153,10 @@ object PdfSkademeldingMapper {
         )
     }
 
-    private fun landNavnEllerKode(landkode: String?, alleLand: Map<Landkode, Land>): String? {
+    private fun landNavnEllerKode(landkode: String?, alleLand: Map<KodeverkKode, KodeverkVerdi>): String? {
         if (landkode == null || landkode == "NO" || landkode == "NOR") return null
         val land = alleLand[landkode]
-        return land?.navn ?: landkode
+        return land?.verdi ?: landkode
     }
 
     private fun lagPdfDokumentInfo(metadata: SkademeldingMetadata): PdfDokumentInfo {

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/KodeverkService.kt
@@ -1,0 +1,41 @@
+package no.nav.yrkesskade.meldingmottak.services
+
+import no.nav.yrkesskade.meldingmottak.clients.Kodeverkklient
+import no.nav.yrkesskade.meldingmottak.domene.*
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Service
+class KodeverkService(
+    private val kodeverkklient: Kodeverkklient,
+    @Value("\${kodeverk.cache.gyldigTidMinutter}") val gyldigTidMinutter: Long = 60
+) {
+    val kodeverkMap: MutableMap<KodeverkTypeKategori, KodeverkTidData> = mutableMapOf()
+
+
+    fun hentKodeverk(type: String, kategori: String, spraak: String = "nb"): Map<KodeverkKode, KodeverkVerdi> {
+        val key = KodeverkTypeKategori(type, kategori)
+
+        if (!gyldig(type, kategori, spraak)) {
+            val map = kodeverkklient.hentKodeverk(type, kategori, spraak)
+            kodeverkMap[key] = KodeverkTidData(map)
+        }
+
+        return kodeverkMap[key]?.data ?: emptyMap()
+    }
+
+
+    private fun gyldig(type: KodeverkType, kategori: KodeverkKategori, spraak: String): Boolean {
+        val key = KodeverkTypeKategori(type, kategori)
+        val kodeverkTidData: KodeverkTidData? = kodeverkMap[key]
+
+        if (kodeverkTidData == null ||
+            kodeverkTidData.hentetTid.isBefore(Instant.now().plus(-gyldigTidMinutter, ChronoUnit.MINUTES))
+        ) {
+            return false
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/PdfService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/PdfService.kt
@@ -29,13 +29,11 @@ class PdfService(
     }
 
     private fun landkoder(spraak: String = "nb"): Map<KodeverkKode, KodeverkVerdi> {
-        var land = mapOf<KodeverkKode, KodeverkVerdi>()
-
         // TODO: Jira-oppgave YSMOD-144: Fjern feature-toggle for henting av land for visning i utenlandske adresser på pdf
         if (featureToggleService.isEnabled(FeatureToggles.LANDKODER_TIL_PDF.toggleId)) {
-            land = kodeverkservice.hentKodeverk("landkoderISO2", "", spraak)
+            return kodeverkservice.hentKodeverk("landkoderISO2", "", spraak)
         }
-        return land
+        return emptyMap()
     }
 }
 

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/PdfService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/PdfService.kt
@@ -1,12 +1,11 @@
 package no.nav.yrkesskade.meldingmottak.services
 
-import no.nav.yrkesskade.meldingmottak.clients.Kodeverkklient
 import no.nav.yrkesskade.meldingmottak.clients.PdfClient
 import no.nav.yrkesskade.meldingmottak.config.FeatureToggleService
 import no.nav.yrkesskade.meldingmottak.config.FeatureToggles
 import no.nav.yrkesskade.meldingmottak.domene.BeriketData
-import no.nav.yrkesskade.meldingmottak.domene.Land
-import no.nav.yrkesskade.meldingmottak.domene.Landkode
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkKode
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkVerdi
 import no.nav.yrkesskade.meldingmottak.pdf.PdfSkademeldingMapper
 import no.nav.yrkesskade.meldingmottak.pdf.domene.PdfSkademelding
 import no.nav.yrkesskade.model.SkademeldingInnsendtHendelse
@@ -15,7 +14,7 @@ import org.springframework.stereotype.Service
 @Service
 class PdfService(
     private val pdfClient: PdfClient,
-    private val kodeverkklient: Kodeverkklient,
+    private val kodeverkservice: KodeverkService,
     private val featureToggleService: FeatureToggleService
 ) {
 
@@ -29,12 +28,12 @@ class PdfService(
         return pdfClient.lagPdf(pdfSkademelding, template)
     }
 
-    private fun landkoder(spraak: String = "nb"): Map<Landkode, Land> {
-        var land = mapOf<Landkode, Land>()
+    private fun landkoder(spraak: String = "nb"): Map<KodeverkKode, KodeverkVerdi> {
+        var land = mapOf<KodeverkKode, KodeverkVerdi>()
 
         // TODO: Jira-oppgave YSMOD-144: Fjern feature-toggle for henting av land for visning i utenlandske adresser på pdf
         if (featureToggleService.isEnabled(FeatureToggles.LANDKODER_TIL_PDF.toggleId)) {
-            land = kodeverkklient.hentLand(spraak)
+            land = kodeverkservice.hentKodeverk("landkoderISO2", "", spraak)
         }
         return land
     }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -67,4 +67,4 @@ no.nav.security.jwt:
           client-auth-method: private_key_jwt
 
 YRKESSKADE_DOKGEN_API_URL: https://yrkesskade-dokgen.dev.intern.nav.no
-YRKESSKADE_KODEVERK_API_URL: http://localhost:8080
+YRKESSKADE_KODEVERK_API_URL: https://yrkesskade-kodeverk.dev.intern.nav.no

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -67,3 +67,4 @@ no.nav.security.jwt:
           client-auth-method: private_key_jwt
 
 YRKESSKADE_DOKGEN_API_URL: https://yrkesskade-dokgen.dev.intern.nav.no
+YRKESSKADE_KODEVERK_API_URL: http://localhost:8080

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -22,7 +22,10 @@ spring:
       group-id: srvc01
   datasource:
     url: jdbc:postgresql://localhost:5432/yrkesskade_mottak
-
+  cloud:
+    gcp:
+      bigquery:
+        enabled: false
 # bruk oneshot for å opprette topic
 kafka:
   topic:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -62,3 +62,4 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 
 YRKESSKADE_DOKGEN_API_URL: http://localhost:5914
+YRKESSKADE_KODEVERK_API_URL: http://localhost:8080

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -67,6 +67,7 @@ no.nav.security.jwt:
           client-auth-method: private_key_jwt
 
 YRKESSKADE_DOKGEN_API_URL: https://yrkesskade-dokgen.intern.nav.no
+YRKESSKADE_KODEVERK_API_URL: https://yrkesskade-kodeverk.intern.nav.no
 saf.graphql.url: https://saf.prod-fss-pub.nais.io/graphql
 pdl.graphql.url: https://pdl-api.prod-fss-pub.nais.io/graphql
 oppgave.url: https://oppgave.prod-fss-pub.nais.io

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -57,3 +57,4 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 
 YRKESSKADE_DOKGEN_API_URL: http://localhost:5914
+YRKESSKADE_KODEVERK_API_URL: http://localhost:8080

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,6 +72,10 @@ prosessering:
     after:
       weeks: 4
 
+kodeverk:
+  cache:
+    gyldigTidMinutter: 60
+
 YRKESSKADE_DOKGEN_API_URL: http://yrkesskade-dokgen.default
 YRKESSKADE_KODEVERK_API_URL: https://yrkesskade-kodeverk.dev.intern.nav.no
 saf.graphql.url: https://saf.dev-fss-pub.nais.io/graphql

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,7 @@ prosessering:
       weeks: 4
 
 YRKESSKADE_DOKGEN_API_URL: http://yrkesskade-dokgen.default
+YRKESSKADE_KODEVERK_API_URL: https://yrkesskade-kodeverk.dev.intern.nav.no
 saf.graphql.url: https://saf.dev-fss-pub.nais.io/graphql
 pdl.graphql.url: https://pdl-api.dev-fss-pub.nais.io/graphql
 oppgave.url: https://oppgave-q1.dev-fss-pub.nais.io

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/KodeverkFixtures.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/KodeverkFixtures.kt
@@ -1,11 +1,11 @@
 package no.nav.yrkesskade.meldingmottak.fixtures
 
-import no.nav.yrkesskade.meldingmottak.domene.Land
-import no.nav.yrkesskade.meldingmottak.domene.Landkode
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkVerdi
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkKode
 
-fun noenLand(): Map<Landkode, Land> {
+fun noenLand(): Map<KodeverkKode, KodeverkVerdi> {
     return mapOf(
-        "NO" to Land("NO", "NORGE"),
-        "SE" to Land("SE", "SVERIGE"),
+        "NO" to KodeverkVerdi("NO", "nb", "NORGE", null),
+        "SE" to KodeverkVerdi("SE", "nb","SVERIGE", null)
     )
 }

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/KodeverkFixtures.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/KodeverkFixtures.kt
@@ -1,0 +1,11 @@
+package no.nav.yrkesskade.meldingmottak.fixtures
+
+import no.nav.yrkesskade.meldingmottak.domene.Land
+import no.nav.yrkesskade.meldingmottak.domene.Landkode
+
+fun noenLand(): Map<Landkode, Land> {
+    return mapOf(
+        "NO" to Land("NO", "NORGE"),
+        "SE" to Land("SE", "SVERIGE"),
+    )
+}

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/SkademeldingFixtures.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/SkademeldingFixtures.kt
@@ -105,7 +105,7 @@ private fun hendelsesfakta(): Hendelsesfakta? {
                 adresselinje1 = "Storgaten 13",
                 adresselinje2 = "2345 Småbygda",
                 adresselinje3 = null,
-                land = "SVERIGE"
+                land = "SE"
             )
         ),
         aarsakUlykkeTabellAogE = listOf(
@@ -139,7 +139,7 @@ fun beriketData(): BeriketData {
             adresselinje1 = "Stigen 7A",
             adresselinje2 = "7730 Småby",
             adresselinje3 = null,
-            land = ""
+            land = "NO"
         )
     )
 }

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/pdf/PdfSkademeldingMapperTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/pdf/PdfSkademeldingMapperTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.yrkesskade.meldingmottak.fixtures.beriketData
 import no.nav.yrkesskade.meldingmottak.fixtures.enkelSkademeldingInnsendtHendelse
+import no.nav.yrkesskade.meldingmottak.fixtures.noenLand
 import no.nav.yrkesskade.meldingmottak.pdf.domene.*
 import no.nav.yrkesskade.skademelding.model.*
 import org.assertj.core.api.Assertions.assertThat
@@ -22,7 +23,7 @@ internal class PdfSkademeldingMapperTest {
         val beriketData = beriketData()
         println("beriket data er:\n $beriketData")
 
-        val pdfSkademelding = PdfSkademeldingMapper.tilPdfSkademelding(record, beriketData)
+        val pdfSkademelding = PdfSkademeldingMapper.tilPdfSkademelding(record, noenLand(), beriketData)
         println("PdfSkademeldingen er $pdfSkademelding")
 
         assertPdfSkademelding(pdfSkademelding)
@@ -57,7 +58,7 @@ internal class PdfSkademeldingMapperTest {
                 adresselinje1 = "Stigen 7A",
                 adresselinje2 = "7730 Småby",
                 adresselinje3 = null,
-                land = ""
+                land = null
             ))
         assertThat(skadelidt?.dekningsforhold?.organisasjonsnummer?.verdi).isEqualTo("123456789")
         assertThat(skadelidt?.dekningsforhold?.navnPaaVirksomheten?.verdi).isEqualTo("Bedriften AS")

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/services/KodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/services/KodeverkServiceTest.kt
@@ -1,0 +1,85 @@
+package no.nav.yrkesskade.meldingmottak.services
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.yrkesskade.meldingmottak.clients.Kodeverkklient
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkTidData
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkTypeKategori
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkVerdi
+import no.nav.yrkesskade.meldingmottak.fixtures.noenLand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.util.ReflectionTestUtils
+import java.time.Instant
+
+@Suppress("NonAsciiCharacters", "INTEGER_OPERATOR_RESOLVE_WILL_CHANGE", "UNCHECKED_CAST")
+@ExtendWith(MockKExtension::class)
+internal class KodeverkServiceTest {
+
+    private val typeLandkoderISO2 = "landkoderISO2"
+    private val kategoriBlank = ""
+    private val bokmaal = "nb"
+    private val keyLandkoder = KodeverkTypeKategori(typeLandkoderISO2, kategoriBlank)
+
+    private val kodeverkklientMock: Kodeverkklient = mockk()
+
+    private val service = KodeverkService(kodeverkklientMock)
+
+
+    @BeforeEach
+    fun setup() {
+        every { kodeverkklientMock.hentKodeverk(any(), any(), any()) } returns noenLand()
+    }
+
+
+    @Test
+    fun `skal hente land fra map når kodeverket finnes fra før`() {
+        val map = mutableMapOf(keyLandkoder to KodeverkTidData(noenLand(), Instant.now()))
+        ReflectionTestUtils.setField(service, "kodeverkMap", map)
+
+        service.hentKodeverk(typeLandkoderISO2, kategoriBlank, bokmaal)
+        verify(exactly = 0) { kodeverkklientMock.hentKodeverk(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal hente land fra api når det er lenge siden kodeveerket ble hentet`() {
+        val forLengeSiden = Instant.MIN
+        val mapMedUtløptKodeverk = mutableMapOf(keyLandkoder to KodeverkTidData(noenLand(), forLengeSiden))
+        ReflectionTestUtils.setField(service, "kodeverkMap", mapMedUtløptKodeverk)
+
+        val map = (ReflectionTestUtils.getField(service, "kodeverkMap") as MutableMap<KodeverkTypeKategori, KodeverkTidData>)
+        val kodeverkTidData = map[keyLandkoder]!!
+        // Data finnes...
+        assertThat(kodeverkTidData.data["NO"]).isEqualTo(KodeverkVerdi("NO", "nb","NORGE", null))
+        // ...men er hentet for mer enn x minutter siden
+        assertThat(kodeverkTidData.hentetTid).isBefore(Instant.now().minusSeconds(60*60))
+
+        service.hentKodeverk(typeLandkoderISO2, kategoriBlank, bokmaal)
+        verify(exactly = 1) { kodeverkklientMock.hentKodeverk(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal hente land fra api når kodeverket ikke finnes fra før`() {
+        val map = (ReflectionTestUtils.getField(service, "kodeverkMap") as MutableMap<KodeverkTypeKategori, KodeverkTidData>)
+        val kodeverkTidData = map[keyLandkoder]
+        // Data finnes ikke...
+        assertThat(kodeverkTidData).isNull()
+
+        service.hentKodeverk(typeLandkoderISO2, kategoriBlank, bokmaal)
+        verify(exactly = 1) { kodeverkklientMock.hentKodeverk(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal returnere tom map når kodeverket ikke finnes i api`() {
+        every { kodeverkklientMock.hentKodeverk(any(), any(), any()) } returns emptyMap()
+
+        val landKodeverk = service.hentKodeverk(typeLandkoderISO2, kategoriBlank, bokmaal)
+        verify(exactly = 1) { kodeverkklientMock.hentKodeverk(any(), any(), any()) }
+        assertThat(landKodeverk).isEmpty()
+    }
+
+}


### PR DESCRIPTION
- Henter ut kodeverk for land og legger inn navn på land i utenlandske adresser for pdf-ene. Hvis landkode for Norge er angitt settes land til blank, slik at det ikke vises i adressene.
- Se spesielt over bruken av feature toggle
- Feature toggle yrkesskade.landkoder-til-pdf er pt slått av, slik at funksjonen for å hente landkoder-kodeverk bare returnerer en tom map