### PR TITLE
Fix/feil i kodeverdirespons

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/domene/Kodeverk.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/domene/Kodeverk.kt
@@ -15,9 +15,7 @@ typealias KodeverkKode = String
 
 data class KodeverkVerdi(
     val kode: String,
-    val spraak: String,
     val verdi: String,
-    val sortering: Int?
 )
 
 data class KodeverdiRespons (

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/SkademeldingService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/SkademeldingService.kt
@@ -8,19 +8,7 @@ import no.nav.yrkesskade.meldingmottak.clients.bigquery.schema.SkademeldingPaylo
 import no.nav.yrkesskade.meldingmottak.clients.bigquery.schema.skademelding_v1
 import no.nav.yrkesskade.meldingmottak.clients.dokarkiv.DokarkivClient
 import no.nav.yrkesskade.meldingmottak.clients.graphql.PdlClient
-import no.nav.yrkesskade.meldingmottak.domene.Adresse
-import no.nav.yrkesskade.meldingmottak.domene.AvsenderMottaker
-import no.nav.yrkesskade.meldingmottak.domene.BeriketData
-import no.nav.yrkesskade.meldingmottak.domene.Bruker
-import no.nav.yrkesskade.meldingmottak.domene.BrukerIdType
-import no.nav.yrkesskade.meldingmottak.domene.Dokument
-import no.nav.yrkesskade.meldingmottak.domene.Dokumentvariant
-import no.nav.yrkesskade.meldingmottak.domene.Dokumentvariantformat
-import no.nav.yrkesskade.meldingmottak.domene.Filtype
-import no.nav.yrkesskade.meldingmottak.domene.Journalposttype
-import no.nav.yrkesskade.meldingmottak.domene.Kanal
-import no.nav.yrkesskade.meldingmottak.domene.Navn
-import no.nav.yrkesskade.meldingmottak.domene.OpprettJournalpostRequest
+import no.nav.yrkesskade.meldingmottak.domene.*
 import no.nav.yrkesskade.meldingmottak.util.getSecureLogger
 import no.nav.yrkesskade.model.SkademeldingInnsendtHendelse
 import org.slf4j.LoggerFactory
@@ -54,11 +42,11 @@ class SkademeldingService(
     fun mottaSkademelding(record: SkademeldingInnsendtHendelse) {
         log.info("Mottatt ny skademelding")
         secureLogger.info("Mottatt ny skademelding: $record")
-        foerMetrikkIBigQuery(record)
         val pdf = pdfService.lagPdf(record, PdfTemplate.SKADEMELDING_TRO_KOPI)
         val beriketPdf = lagBeriketPdf(record)
         val opprettJournalpostRequest = mapSkademeldingTilOpprettJournalpostRequest(record, pdf, beriketPdf)
         dokarkivClient.journalfoerSkademelding(opprettJournalpostRequest)
+        foerMetrikkIBigQuery(record)
     }
 
     private fun foerMetrikkIBigQuery(record: SkademeldingInnsendtHendelse) {

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/KodeverkFixtures.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/fixtures/KodeverkFixtures.kt
@@ -1,11 +1,11 @@
 package no.nav.yrkesskade.meldingmottak.fixtures
 
-import no.nav.yrkesskade.meldingmottak.domene.KodeverkVerdi
 import no.nav.yrkesskade.meldingmottak.domene.KodeverkKode
+import no.nav.yrkesskade.meldingmottak.domene.KodeverkVerdi
 
 fun noenLand(): Map<KodeverkKode, KodeverkVerdi> {
     return mapOf(
-        "NO" to KodeverkVerdi("NO", "nb", "NORGE", null),
-        "SE" to KodeverkVerdi("SE", "nb","SVERIGE", null)
+        "NO" to KodeverkVerdi("NO", "NORGE"),
+        "SE" to KodeverkVerdi("SE", "SVERIGE")
     )
 }

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/services/KodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/services/KodeverkServiceTest.kt
@@ -54,7 +54,7 @@ internal class KodeverkServiceTest {
         val map = (ReflectionTestUtils.getField(service, "kodeverkMap") as MutableMap<KodeverkTypeKategori, KodeverkTidData>)
         val kodeverkTidData = map[keyLandkoder]!!
         // Data finnes...
-        assertThat(kodeverkTidData.data["NO"]).isEqualTo(KodeverkVerdi("NO", "nb","NORGE", null))
+        assertThat(kodeverkTidData.data["NO"]).isEqualTo(KodeverkVerdi("NO", "NORGE"))
         // ...men er hentet for mer enn x minutter siden
         assertThat(kodeverkTidData.hentetTid).isBefore(Instant.now().minusSeconds(60*60))
 


### PR DESCRIPTION
Respons bør flyttes ut i fellesmodul, slik at endringer i responsen ikke fører til at konsumenten feiler. Har opprettet jira-oppgave YSMOD-191 for dette.

Burde vi sett nærmere på transaksjonshåndteringen i mottak? Ref føring av metrikker ikke ruller tilbake inserts.