### PR TITLE
YSMOD-198 lagt til reglene for YRK for behandlingstema/behandlingstype

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/gosys/Oppgave.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/gosys/Oppgave.kt
@@ -90,6 +90,24 @@ enum class Statuskategori {
     AAPEN, AVSLUTTET
 }
 
+/**
+ * Enum for mapping fra enkelte brevkoder til behandlingstema og behandlingstype.
+ * Behandlingstema og behandlingstype sendes til Oppgave-API for å sørge for at brevene under får satt riktig
+ * "Gjelder-kode" i Gosys og rutes til riktig enhet.
+ * Kodene hentes "egentlig" med oppslag mot felles kodeverk, men det er så få som gjelder YRK, så vi kan bare ha dem her.
+ *
+ * Beskrivelse av brevkoder:
+ * UTL:             Brev - utland
+ *
+ * NAVe 13-13.05:   Ettersendelse til søknad fra selvstendig næringsdrivende og frilansere om opptak i
+ *                  frivillig trygd med rett til særytelser ved yrkesskade
+ *
+ * NAVe 13-07.05:   Ettersendelse til melding om yrkesskade eller yrkessykdom som er
+ *                  påført under arbeid på norsk eller utenlandsk landterritorium
+ *
+ * NAV 13-13.05:    Søknad fra selvstendig næringsdrivende og frilansere om opptak i frivillig trygd
+ *                  med rett til særytelser ved yrkesskade
+ */
 enum class KrutkodeMapping(val brevkode: String?, val behandlingstema: String?, val behandlingstype: String?) {
     UTL("UTL", "ab0276", "ae0106"),
     NAVe_13_13_05("NAVe 13-13.05", "ab0085", null),

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/gosys/Oppgave.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/clients/gosys/Oppgave.kt
@@ -90,4 +90,16 @@ enum class Statuskategori {
     AAPEN, AVSLUTTET
 }
 
+enum class KrutkodeMapping(val brevkode: String?, val behandlingstema: String?, val behandlingstype: String?) {
+    UTL("UTL", "ab0276", "ae0106"),
+    NAVe_13_13_05("NAVe 13-13.05", "ab0085", null),
+    NAVe_13_07_05("NAVe 13-07.05", "ab0276", null),
+    NAV_13_13_05("NAV 13-13.05", "ab0085", null),
+    UKJENT(null, null, null);
+
+    companion object {
+        fun fromBrevkode(brevkode: String?) = values().find { it.brevkode == brevkode?.trim() } ?: UKJENT
+    }
+}
+
 

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/task/ProsesserJournalfoeringHendelseTask.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/task/ProsesserJournalfoeringHendelseTask.kt
@@ -12,6 +12,7 @@ import no.nav.familie.log.mdc.MDCConstants
 import no.nav.yrkesskade.meldingmottak.clients.bigquery.BigQueryClient
 import no.nav.yrkesskade.meldingmottak.clients.bigquery.schema.JournalfoeringHendelseOppgavePayload
 import no.nav.yrkesskade.meldingmottak.clients.bigquery.schema.journalfoeringhendelse_oppgave_v1
+import no.nav.yrkesskade.meldingmottak.clients.gosys.KrutkodeMapping
 import no.nav.yrkesskade.meldingmottak.clients.gosys.Oppgave
 import no.nav.yrkesskade.meldingmottak.clients.gosys.OppgaveClient
 import no.nav.yrkesskade.meldingmottak.clients.gosys.Oppgavetype
@@ -178,6 +179,7 @@ class ProsesserJournalfoeringHendelseTask(
 
     fun opprettOppgave(journalpost: Journalpost): Oppgave {
         val aktoerId = hentAktoerId(journalpost.bruker)
+        val krutkoder = KrutkodeMapping.fromBrevkode(journalpost.hentBrevkode())
 
         val journalfoeringOppgave = OpprettJournalfoeringOppgave(
             beskrivelse = journalpost.hentHovedDokumentTittel(),
@@ -186,8 +188,8 @@ class ProsesserJournalfoeringHendelseTask(
             tema = journalpost.tema.toString(),
             tildeltEnhetsnr = journalpost.journalfoerendeEnhetEllerNull(),
             oppgavetype = Oppgavetype.JOURNALFOERING.kortnavn,
-            behandlingstema = null, // skal være null
-            behandlingstype = null, // skal være null
+            behandlingstema = krutkoder.behandlingstema,
+            behandlingstype = krutkoder.behandlingstype,
             prioritet = Prioritet.NORM,
             fristFerdigstillelse = FristFerdigstillelseTimeManager.nesteGyldigeFristForFerdigstillelse(journalpost.datoOpprettet),
             aktivDato = journalpost.datoOpprettet.toLocalDate()

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/clients/gosys/KrutkodeMappingTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/clients/gosys/KrutkodeMappingTest.kt
@@ -1,0 +1,71 @@
+package no.nav.yrkesskade.meldingmottak.clients.gosys
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class KrutkodeMappingTest {
+
+    @Test
+    fun `UTL skal gi behandlingstema ab0276 og behandlingstype ae0106`() {
+        val mapping = KrutkodeMapping.fromBrevkode("UTL")
+        assertThat(mapping.behandlingstema).isEqualTo("ab0276")
+        assertThat(mapping.behandlingstype).isEqualTo("ae0106")
+    }
+
+    @Test
+    fun `NAVe 13 13 05 skal gi behandlingstema ab0085 og behandlingstype null`() {
+        val mapping = KrutkodeMapping.fromBrevkode("NAVe 13-13.05")
+        assertThat(mapping.behandlingstema).isEqualTo("ab0085")
+        assertThat(mapping.behandlingstype).isNull()
+    }
+
+    @Test
+    fun `NAVe 13 07 05 skal gi behandlingstema ab0276 og behandlingstype null`() {
+        val mapping = KrutkodeMapping.fromBrevkode("NAVe 13-07.05")
+        assertThat(mapping.behandlingstema).isEqualTo("ab0276")
+        assertThat(mapping.behandlingstype).isNull()
+    }
+
+    @Test
+    fun `NAV 13 13 05 skal gi behandlingstema ab0085 og behandlingstype null`() {
+        val mapping = KrutkodeMapping.fromBrevkode("NAV 13-13.05")
+        assertThat(mapping.behandlingstema).isEqualTo("ab0085")
+        assertThat(mapping.behandlingstype).isNull()
+    }
+
+    @Test
+    fun `ukjent brevkode skal gi UKJENT`() {
+        val mapping = KrutkodeMapping.fromBrevkode("eksisterer ikke")
+        assertThat(mapping).isEqualTo(KrutkodeMapping.UKJENT)
+        assertThat(mapping.behandlingstema).isNull()
+        assertThat(mapping.behandlingstype).isNull()
+    }
+
+    @Test
+    fun `fromBrevkode skal haandtere null som input`() {
+        val mapping = KrutkodeMapping.fromBrevkode(null)
+        assertThat(mapping).isEqualTo(KrutkodeMapping.UKJENT)
+        assertThat(mapping.behandlingstema).isNull()
+        assertThat(mapping.behandlingstype).isNull()
+    }
+
+    @Test
+    fun `fromBrevkode skal haandtere tom streng som input`() {
+        val mapping = KrutkodeMapping.fromBrevkode("")
+        assertThat(mapping).isEqualTo(KrutkodeMapping.UKJENT)
+        assertThat(mapping.behandlingstema).isNull()
+        assertThat(mapping.behandlingstype).isNull()
+    }
+
+    @Test
+    fun `skal kunne matche selv om det er whitespace bak brevkoden`() {
+        val mapping = KrutkodeMapping.fromBrevkode("UTL ")
+        assertThat(mapping).isEqualTo(KrutkodeMapping.UTL)
+    }
+
+    @Test
+    fun `skal kunne matche selv om det er whitespace foran brevkoden`() {
+        val mapping = KrutkodeMapping.fromBrevkode(" UTL")
+        assertThat(mapping).isEqualTo(KrutkodeMapping.UTL)
+    }
+}


### PR DESCRIPTION
Med disse reglene får vi enda mer nøyaktig ruting av oppgaver. Det er enkelte brevkoder som skal rutes til spesifikke enheter; ved å sette såkalte behandlingstyper og behandlingstema fra kodeverket, får Oppgave informasjonen som er nødvendig for å rute til riktig enhet.