### PR TITLE
Start skadeforklaring-listener kun i dev, ikke i prod

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/hendelser/SkadeforklaringInnsendingHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/hendelser/SkadeforklaringInnsendingHendelseConsumer.kt
@@ -3,6 +3,7 @@ package no.nav.yrkesskade.meldingmottak.hendelser
 import no.nav.yrkesskade.meldingmottak.integration.mottak.model.SkadeforklaringInnsendingHendelse
 import no.nav.yrkesskade.meldingmottak.services.SkadeforklaringService
 import no.nav.yrkesskade.meldingmottak.util.kallMetodeMedCallId
+import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
 import javax.transaction.Transactional
@@ -12,12 +13,13 @@ class SkadeforklaringInnsendingHendelseConsumer(
     private val skadeforklaringService: SkadeforklaringService
 ) {
 
-//    @KafkaListener(
-//        id = "skadeforklaring-innsendt",
-//        topics = ["\${kafka.topic.skadeforklaring-innsendt}"],
-//        containerFactory = "skadeforklaringInnsendingHendelseListenerContainerFactory",
-//        idIsGroup = false
-//    )
+    @KafkaListener(
+        id = "skadeforklaring-innsendt",
+        topics = ["\${kafka.topic.skadeforklaring-innsendt.name}"],
+        containerFactory = "skadeforklaringInnsendingHendelseListenerContainerFactory",
+        idIsGroup = false,
+        autoStartup = "\${kafka.topic.skademelding-innsendt.auto-startup:true}"
+    )
     @Transactional
     fun listen(@Payload record: SkadeforklaringInnsendingHendelse) {
         kallMetodeMedCallId(record.metadata.navCallId) {

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/hendelser/SkadeforklaringInnsendingHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/hendelser/SkadeforklaringInnsendingHendelseConsumer.kt
@@ -18,7 +18,7 @@ class SkadeforklaringInnsendingHendelseConsumer(
         topics = ["\${kafka.topic.skadeforklaring-innsendt.name}"],
         containerFactory = "skadeforklaringInnsendingHendelseListenerContainerFactory",
         idIsGroup = false,
-        autoStartup = "\${kafka.topic.skademelding-innsendt.auto-startup:true}"
+        autoStartup = "\${kafka.topic.skadeforklaring-innsendt.auto-startup:true}"
     )
     @Transactional
     fun listen(@Payload record: SkadeforklaringInnsendingHendelse) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -25,7 +25,8 @@ kafka:
   topic:
     aapen-dok-journalfoering: teamdokumenthandtering.aapen-dok-journalfoering-q1
     skademelding-innsendt: yrkesskade.privat-yrkesskade-skademeldinginnsendt
-    skadeforklaring-innsendt: yrkesskade.privat-yrkesskade-skadeforklaringinnsendt
+    skadeforklaring-innsendt:
+      name: yrkesskade.privat-yrkesskade-skadeforklaringinnsendt
 
 no.nav.security.jwt:
   issuer:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -31,7 +31,8 @@ kafka:
   topic:
     aapen-dok-journalfoering: aapen-dok-journalfoering
     skademelding-innsendt: privat-yrkesskade-skademeldinginnsendt
-    skadeforklaring-innsendt: privat-yrkesskade-skadeforklaringinnsendt
+    skadeforklaring-innsendt:
+      name: privat-yrkesskade-skadeforklaringinnsendt
 
 no.nav.security.jwt:
   issuer:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -25,7 +25,9 @@ kafka:
   topic:
     aapen-dok-journalfoering: teamdokumenthandtering.aapen-dok-journalfoering
     skademelding-innsendt: yrkesskade.privat-yrkesskade-skademeldinginnsendt
-    skadeforklaring-innsendt: yrkesskade.privat-yrkesskade-skadeforklaringinnsendt
+    skadeforklaring-innsendt:
+      name: yrkesskade.privat-yrkesskade-skadeforklaringinnsendt
+      auto-startup: false
 
 no.nav.security.jwt:
   issuer:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -17,7 +17,8 @@ kafka:
   topic:
     aapen-dok-journalfoering: test
     skademelding-innsendt: yrkesskade.privat-yrkesskade-skademeldinginnsendt
-    skadeforklaring-innsendt: yrkesskade.privat-yrkesskade-skadeforklaringinnsendt
+    skadeforklaring-innsendt:
+      name: yrkesskade.privat-yrkesskade-skadeforklaringinnsendt
 
 funksjonsbrytere:
   enabled: false

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/hendelser/SkadeforklaringInnsendingHendelseConsumerIT.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/hendelser/SkadeforklaringInnsendingHendelseConsumerIT.kt
@@ -4,7 +4,6 @@ import no.nav.yrkesskade.meldingmottak.BaseSpringBootTestClass
 import no.nav.yrkesskade.meldingmottak.fixtures.skadeforklaringInnsendingHendelse
 import no.nav.yrkesskade.meldingmottak.integration.mottak.model.SkadeforklaringInnsendingHendelse
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -23,7 +22,6 @@ private const val NUM_BROKERS = 1
 
 private const val CONTROLLED_BROKER_SHUTDOWN = true
 
-@Disabled("Disabled ved automatisk testkjøring")
 @EmbeddedKafka(topics = [TOPIC])
 internal class SkadeforklaringInnsendingHendelseConsumerIT : BaseSpringBootTestClass() {
 
@@ -48,7 +46,6 @@ internal class SkadeforklaringInnsendingHendelseConsumerIT : BaseSpringBootTestC
         }
     }
 
-    @Disabled("Disabled ved automatisk testkjøring")
     @Test
     fun listen() {
         val record = skadeforklaringInnsendingHendelse()


### PR DESCRIPTION
Deploy på fredag skapte mange advarsler i loggen fordi kafka topic for skadeforklaring ikke er lagt i prod. Kommenterte da ut listener som en quick fix. 
Har nå, etter tips fra Erik, lagt på property-basert løsning for å kjøre listener i dev men ikke i prod, slik det ble gjort med digital skademelding (revisjon 8b1ca78b2be459f8517451d22c3805ef58b1a6e7).