### PR TITLE
Bugfix/task prosessering index begrensning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>no.nav.yrkesskade</groupId>
             <artifactId>prosessering-jdbc</artifactId>
-            <version>1.20220318100229_f8cb856</version>
+            <version>1.20220603094306_96361ef</version>
         </dependency>
 
         <!-- Diverse -->

--- a/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/SkademeldingService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/meldingmottak/services/SkademeldingService.kt
@@ -47,8 +47,9 @@ class SkademeldingService(
         val pdf = pdfService.lagPdf(record, PdfTemplate.SKADEMELDING_TRO_KOPI)
         val beriketPdf = lagBeriketPdf(record, PdfTemplate.SKADEMELDING_SAKSBEHANDLING)
         val opprettJournalpostRequest = mapSkademeldingTilOpprettJournalpostRequest(record, pdf, beriketPdf)
-        dokarkivClient.journalfoerDokument(opprettJournalpostRequest)
-        foerMetrikkIBigQuery(record)
+        dokarkivClient.journalfoerDokument(opprettJournalpostRequest)?.also {
+            foerMetrikkIBigQuery(record)
+        }
     }
 
 

--- a/src/main/resources/db/migration/V2__payload_hash.sql
+++ b/src/main/resources/db/migration/V2__payload_hash.sql
@@ -1,0 +1,6 @@
+ALTER TABLE task DROP CONSTRAINT task_payload_key;
+
+ALTER TABLE task ADD COLUMN payload_hash TEXT NOT NULL DEFAULT '';
+UPDATE task SET payload_hash = md5(payload);
+
+ALTER TABLE task ADD CONSTRAINT payload_hash_key UNIQUE (payload_hash);

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/repository/TaskDatabaseIT.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/repository/TaskDatabaseIT.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.postgresql.util.PSQLException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -16,6 +15,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.transaction.annotation.Transactional
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 
 /**
  * Test at databasetabeller er opprettet for Task. Mer utførlige db-tester for task, finnes i kode-repository
@@ -113,7 +113,7 @@ class TaskDatabaseIT {
                     "(id, payload, payload_hash, status, versjon, opprettet_tid, type, metadata, trigger_tid, avvikstype) " +
                     "values(102, 'blabla', 'en fin hashverdi', 'FIN-FIN', 1, '2022-01-19', 'TYPE1', 'noen metadata', '2022-01-19', 'ANNET')"
         )
-        val thrown = assertThrows<PSQLException> { insertForDuplisertTask.executeUpdate() }
+        val thrown = assertThrows<SQLException> { insertForDuplisertTask.executeUpdate() }
         assertThat(thrown.message).contains("""duplicate key value violates unique constraint "payload_hash_key"""")
     }
 

--- a/src/test/kotlin/no/nav/yrkesskade/meldingmottak/repository/TaskDatabaseIT.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/meldingmottak/repository/TaskDatabaseIT.kt
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.postgresql.util.PSQLException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -89,6 +91,30 @@ class TaskDatabaseIT {
 
         val loggerResult = select.executeQuery()
         assertThat(loggerResult.next()).isTrue
+    }
+
+    @Test
+    fun `skal ikke kunne lagre to tasker med identisk payload`() {
+        assertThat(connection.isValid(0)).isTrue
+
+        val select = connection.prepareStatement("select * from task")
+        val emptyResultSet = select.executeQuery()
+        assertThat(emptyResultSet.next()).isFalse
+
+        val insert = connection.prepareStatement(
+            "insert into task " +
+                    "(id, payload, payload_hash, status, versjon, opprettet_tid, type, metadata, trigger_tid, avvikstype) " +
+                    "values(101, 'blabla', 'en fin hashverdi', 'FIN-FIN', 1, '2022-01-19', 'TYPE1', 'noen metadata', '2022-01-19', 'ANNET')"
+        )
+        insert.executeUpdate()
+
+        val insertForDuplisertTask = connection.prepareStatement(
+            "insert into task " +
+                    "(id, payload, payload_hash, status, versjon, opprettet_tid, type, metadata, trigger_tid, avvikstype) " +
+                    "values(102, 'blabla', 'en fin hashverdi', 'FIN-FIN', 1, '2022-01-19', 'TYPE1', 'noen metadata', '2022-01-19', 'ANNET')"
+        )
+        val thrown = assertThrows<PSQLException> { insertForDuplisertTask.executeUpdate() }
+        assertThat(thrown.message).contains("""duplicate key value violates unique constraint "payload_hash_key"""")
     }
 
     @AfterEach


### PR DESCRIPTION
Fjernet unique constraint på payload da unique index ikke håndterer så store payloader som vi har. Legger til ny kolonne payload_hash, og har heller unique constraint på den.